### PR TITLE
Issue with class inheritance in RatingsHelper

### DIFF
--- a/views/helpers/rating.php
+++ b/views/helpers/rating.php
@@ -9,6 +9,8 @@
  * @license MIT License (http://www.opensource.org/licenses/mit-license.php)
  */
 
+App::import('Helper', 'Html');
+
 /**
  * CakePHP Ratings Plugin
  *


### PR DESCRIPTION
I've seen this come up a couple times in #cakephp recently, so I figured it would be prudent to fix. I've App::import()'d the HtmlHelper before the class is declared.
